### PR TITLE
[Alert search bar] Replace the status filter with controls on the observability alerts page

### DIFF
--- a/x-pack/plugins/observability_solution/observability/public/components/alert_search_bar/alert_search_bar.test.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/alert_search_bar/alert_search_bar.test.tsx
@@ -10,15 +10,17 @@ import { waitFor } from '@testing-library/react';
 import { timefilterServiceMock } from '@kbn/data-plugin/public/query/timefilter/timefilter_service.mock';
 import { uiSettingsServiceMock } from '@kbn/core-ui-settings-browser-mocks';
 
-import { ObservabilityAlertSearchBarProps, Services } from './types';
-import { ObservabilityAlertSearchBar } from './alert_search_bar';
 import { observabilityAlertFeatureIds } from '../../../common/constants';
+import { kibanaStartMock } from '../../utils/kibana_react.mock';
 import { render } from '../../utils/test_helper';
+import { ObservabilityAlertSearchBar } from './alert_search_bar';
+import { ObservabilityAlertSearchBarProps, Services } from './types';
 
 const getAlertsSearchBarMock = jest.fn();
 const ALERT_SEARCH_BAR_DATA_TEST_SUBJ = 'alerts-search-bar';
 
 describe('ObservabilityAlertSearchBar', () => {
+  const { http, data, dataViews, notifications, spaces } = kibanaStartMock.startContract().services;
   const renderComponent = (
     props: Partial<ObservabilityAlertSearchBarProps> = {},
     services: Partial<Services> = {}
@@ -33,6 +35,8 @@ describe('ObservabilityAlertSearchBar', () => {
       onStatusChange: jest.fn(),
       onEsQueryChange: jest.fn(),
       onFiltersChange: jest.fn(),
+      onControlConfigsChange: jest.fn(),
+      onControlFiltersChange: jest.fn(),
       setSavedQuery: jest.fn(),
       rangeTo: 'now',
       rangeFrom: 'now-15m',
@@ -44,6 +48,11 @@ describe('ObservabilityAlertSearchBar', () => {
           <div data-test-subj={ALERT_SEARCH_BAR_DATA_TEST_SUBJ} />
         ),
         useToasts: jest.fn(),
+        http,
+        data,
+        dataViews,
+        notifications,
+        spaces,
         ...services,
       },
       ...props,

--- a/x-pack/plugins/observability_solution/observability/public/components/alert_search_bar/alert_search_bar_with_url_sync.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/alert_search_bar/alert_search_bar_with_url_sync.tsx
@@ -21,21 +21,36 @@ function AlertSearchbarWithUrlSync(props: AlertSearchBarWithUrlSyncProps) {
   const { urlStorageKey, defaultState = DEFAULT_STATE, ...searchBarProps } = props;
   const stateProps = useAlertSearchBarStateContainer(urlStorageKey, undefined, defaultState);
   const {
-    data: {
-      query: {
-        timefilter: { timefilter: timeFilterService },
-      },
-    },
+    data,
     triggersActionsUi: { getAlertsSearchBar: AlertsSearchBar },
     uiSettings,
+    http,
+    dataViews,
+    spaces,
+    notifications,
   } = useKibana().services;
+  const {
+    query: {
+      timefilter: { timefilter: timeFilterService },
+    },
+  } = data;
 
   return (
     <ObservabilityAlertSearchBar
       {...stateProps}
       {...searchBarProps}
       showFilterBar
-      services={{ timeFilterService, AlertsSearchBar, useToasts, uiSettings }}
+      services={{
+        timeFilterService,
+        AlertsSearchBar,
+        http,
+        data,
+        dataViews,
+        notifications,
+        spaces,
+        useToasts,
+        uiSettings,
+      }}
     />
   );
 }

--- a/x-pack/plugins/observability_solution/observability/public/components/alert_search_bar/containers/state_container.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/alert_search_bar/containers/state_container.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { FilterControlConfig as ControlConfig } from '@kbn/alerts-ui-shared';
 import { Filter } from '@kbn/es-query';
 import {
   createStateContainer,
@@ -33,6 +34,12 @@ interface AlertSearchBarStateTransitions {
   setSavedQueryId: (
     state: AlertSearchBarContainerState
   ) => (savedQueryId?: string) => AlertSearchBarContainerState;
+  setControlFilters: (
+    state: AlertSearchBarContainerState
+  ) => (controlFilters: Filter[]) => AlertSearchBarContainerState;
+  setControlConfigs: (
+    state: AlertSearchBarContainerState
+  ) => (controlConfigs: ControlConfig[]) => AlertSearchBarContainerState;
 }
 
 const DEFAULT_STATE: AlertSearchBarContainerState = {
@@ -41,6 +48,8 @@ const DEFAULT_STATE: AlertSearchBarContainerState = {
   kuery: '',
   status: ALL_ALERTS.status,
   filters: [],
+  controlFilters: [],
+  controlConfigs: [],
 };
 
 const transitions: AlertSearchBarStateTransitions = {
@@ -50,6 +59,8 @@ const transitions: AlertSearchBarStateTransitions = {
   setStatus: (state) => (status) => ({ ...state, status }),
   setFilters: (state) => (filters) => ({ ...state, filters }),
   setSavedQueryId: (state) => (savedQueryId) => ({ ...state, savedQueryId }),
+  setControlFilters: (state) => (controlFilters) => ({ ...state, controlFilters }),
+  setControlConfigs: (state) => (controlConfigs) => ({ ...state, controlConfigs }),
 };
 
 const alertSearchBarStateContainer = createStateContainer(DEFAULT_STATE, transitions);

--- a/x-pack/plugins/observability_solution/observability/public/components/alert_search_bar/containers/use_alert_search_bar_state_container.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/alert_search_bar/containers/use_alert_search_bar_state_container.tsx
@@ -50,12 +50,26 @@ export function useAlertSearchBarStateContainer(
 
   useUrlStateSyncEffect(stateContainer, urlStorageKey, replace, defaultState);
 
-  const { setRangeFrom, setRangeTo, setKuery, setStatus, setFilters, setSavedQueryId } =
-    stateContainer.transitions;
-  const { rangeFrom, rangeTo, kuery, status, filters, savedQueryId } = useContainerSelector(
-    stateContainer,
-    (state) => state
-  );
+  const {
+    setRangeFrom,
+    setRangeTo,
+    setKuery,
+    setStatus,
+    setFilters,
+    setSavedQueryId,
+    setControlFilters,
+    setControlConfigs,
+  } = stateContainer.transitions;
+  const {
+    rangeFrom,
+    rangeTo,
+    kuery,
+    status,
+    filters,
+    savedQueryId,
+    controlFilters,
+    controlConfigs,
+  } = useContainerSelector(stateContainer, (state) => state);
 
   useEffect(() => {
     if (!savedQuery) {
@@ -94,6 +108,10 @@ export function useAlertSearchBarStateContainer(
     onRangeToChange: setRangeTo,
     onStatusChange: setStatus,
     onFiltersChange: setFilters,
+    onControlFiltersChange: setControlFilters,
+    onControlConfigsChange: setControlConfigs,
+    controlFilters,
+    controlConfigs,
     filters,
     rangeFrom,
     rangeTo,

--- a/x-pack/plugins/observability_solution/observability/public/components/alert_search_bar/types.ts
+++ b/x-pack/plugins/observability_solution/observability/public/components/alert_search_bar/types.ts
@@ -6,8 +6,16 @@
  */
 
 import { ReactElement } from 'react';
-import { ToastsStart } from '@kbn/core-notifications-browser';
-import { type SavedQuery, TimefilterContract } from '@kbn/data-plugin/public';
+import { FilterControlConfig as ControlConfig } from '@kbn/alerts-ui-shared';
+import type { HttpStart } from '@kbn/core-http-browser';
+import { type NotificationsStart, ToastsStart } from '@kbn/core-notifications-browser';
+import {
+  DataPublicPluginStart,
+  type SavedQuery,
+  TimefilterContract,
+} from '@kbn/data-plugin/public';
+import { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import { AlertsSearchBarProps } from '@kbn/triggers-actions-ui-plugin/public/application/sections/alerts_search_bar';
 import { BoolQuery, Filter, Query } from '@kbn/es-query';
 import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
@@ -37,6 +45,11 @@ export interface Dependencies {
 export interface Services {
   timeFilterService: TimefilterContract;
   AlertsSearchBar: (props: AlertsSearchBarProps) => ReactElement<AlertsSearchBarProps>;
+  http: HttpStart;
+  data: DataPublicPluginStart;
+  dataViews: DataViewsPublicPluginStart;
+  notifications: NotificationsStart;
+  spaces?: SpacesPluginStart;
   useToasts: () => ToastsStart;
   uiSettings: IUiSettingsClient;
 }
@@ -57,6 +70,8 @@ export interface AlertSearchBarContainerState {
   status: AlertStatus;
   filters?: Filter[];
   savedQueryId?: string;
+  controlFilters?: Filter[];
+  controlConfigs?: ControlConfig[];
 }
 
 interface AlertSearchBarStateTransitions {
@@ -66,6 +81,8 @@ interface AlertSearchBarStateTransitions {
   onStatusChange: (status: AlertStatus) => void;
   onFiltersChange?: (filters: Filter[]) => void;
   setSavedQuery?: (savedQueryId?: SavedQuery) => void;
+  onControlFiltersChange: (controlFilters: Filter[]) => void;
+  onControlConfigsChange: (controlConfigs: ControlConfig[]) => void;
 }
 
 interface CommonAlertSearchBarProps {

--- a/x-pack/plugins/observability_solution/observability/public/pages/alerts/alerts.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/pages/alerts/alerts.tsx
@@ -66,6 +66,7 @@ function InternalAlertsPage() {
     share: {
       url: { locators },
     },
+    spaces,
     triggersActionsUi: {
       alertsTableConfigurationRegistry,
       getAlertsSearchBar: AlertsSearchBar,
@@ -240,7 +241,17 @@ function InternalAlertsPage() {
               appName={ALERTS_SEARCH_BAR_ID}
               onEsQueryChange={setEsQuery}
               showFilterBar
-              services={{ timeFilterService, AlertsSearchBar, useToasts, uiSettings }}
+              services={{
+                timeFilterService,
+                AlertsSearchBar,
+                http,
+                data,
+                dataViews,
+                notifications,
+                spaces,
+                useToasts,
+                uiSettings,
+              }}
             />
           </EuiFlexItem>
           <EuiFlexItem>

--- a/x-pack/plugins/observability_solution/observability/public/plugin.mock.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/plugin.mock.tsx
@@ -8,9 +8,11 @@
 import React from 'react';
 import { mockCasesContract } from '@kbn/cases-plugin/public/mocks';
 import { chartPluginMock } from '@kbn/charts-plugin/public/mocks';
-import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import { contentManagementMock } from '@kbn/content-management-plugin/public/mocks';
+import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
+import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
 import { sharePluginMock } from '@kbn/share-plugin/public/mocks';
+import { spacesPluginMock } from '@kbn/spaces-plugin/public/mocks';
 import { unifiedSearchPluginMock } from '@kbn/unified-search-plugin/public/mocks';
 import type { AlertActionsProps } from '@kbn/triggers-actions-ui-plugin/public/types';
 import { getAlertsTableDefaultAlertActionsLazy } from '@kbn/triggers-actions-ui-plugin/public/common/get_alerts_table_default_row_actions';
@@ -103,20 +105,6 @@ const dataViewEditor = {
   },
 };
 
-const dataViews = {
-  createStart() {
-    return {
-      getIds: jest.fn().mockImplementation(() => []),
-      get: jest.fn(),
-      create: jest.fn().mockImplementation(() => ({
-        fields: {
-          getByName: jest.fn(),
-        },
-      })),
-    };
-  },
-};
-
 export const observabilityPublicPluginsStartMock = {
   createStart() {
     return {
@@ -125,10 +113,11 @@ export const observabilityPublicPluginsStartMock = {
       contentManagement: contentManagementMock.createStartContract(),
       data: dataPluginMock.createStartContract(),
       dataViewEditor: dataViewEditor.createStart(),
-      dataViews: dataViews.createStart(),
+      dataViews: dataViewPluginMocks.createStartContract(),
       discover: null,
       lens: lensPluginMock.createStartContract(),
       share: sharePluginMock.createStartContract(),
+      spaces: spacesPluginMock.createStartContract(),
       triggersActionsUi: triggersActionsUiStartMock.createStart(),
       unifiedSearch: unifiedSearchPluginMock.createStartContract(),
     };


### PR DESCRIPTION
Closes #197953

## Summary

This PR replaces the alert status filter with filter controls.

We need to fix the following items before merging this feature:
- [ ] Solving the permission issue
    - The main issue will be fixed in this [PR](https://github.com/elastic/kibana/pull/191110)
    - In the above [PR](https://github.com/elastic/kibana/pull/191110), we remove controls if the user does not have the privilege for alert indices, but we need to figure out how to adjust filter controls to access the data based on Kibana privileges.
- [ ] We should configure the filters to allow the selection of one item for alert status but still show the other options
- [ ] Changing the URL does not update the page filters correctly. Might be related to https://github.com/elastic/kibana/issues/183412.
- [ ] We need to make sure these adjustments work as expected in APM as they use the observability alert search bar.
- [ ] Check if the tags filter can be improved, and if not, whether it makes sense to keep it in its current form.