### PR TITLE
Suggestion for tests

### DIFF
--- a/src/platform/test/analytics/plugins/analytics_plugin_a/server/plugin.ts
+++ b/src/platform/test/analytics/plugins/analytics_plugin_a/server/plugin.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import apm from 'elastic-apm-node';
 import { BehaviorSubject, filter, firstValueFrom, ReplaySubject } from 'rxjs';
 import { takeWhile, tap, toArray } from 'rxjs';
 import { schema } from '@kbn/config-schema';
@@ -42,6 +43,13 @@ export class AnalyticsPluginAPlugin implements Plugin {
             description: 'The lifecycle step in which the plugin is',
           },
         },
+        traceId: {
+          type: 'keyword',
+          _meta: {
+            description: 'The trace ID of the APM transaction',
+            optional: true,
+          },
+        },
       },
     });
 
@@ -49,6 +57,7 @@ export class AnalyticsPluginAPlugin implements Plugin {
     reportEvent('test-plugin-lifecycle', {
       plugin: 'analyticsPluginA',
       step: 'setup',
+      traceId: apm.currentTraceIds?.['trace.id'],
     });
 
     const actions$ = new ReplaySubject<Action>();
@@ -137,6 +146,7 @@ export class AnalyticsPluginAPlugin implements Plugin {
     analytics.reportEvent('test-plugin-lifecycle', {
       plugin: 'analyticsPluginA',
       step: 'start',
+      traceId: apm.currentTraceIds?.['trace.id'],
     });
   }
 

--- a/src/platform/test/analytics/tests/analytics_from_the_browser.ts
+++ b/src/platform/test/analytics/tests/analytics_from_the_browser.ts
@@ -148,19 +148,20 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         // This helps us to also test the helpers
         const events = await ebtUIHelper.getEvents(2, { eventTypes: ['test-plugin-lifecycle'] });
-        events.forEach(({ trace }) => expect(trace).to.have.property('id'));
-        expect(events.map(({ trace, ...rest }) => rest)).to.eql([
+        expect(events).to.eql([
           {
             timestamp: reportTestPluginLifecycleEventsAction!.meta[setupEvent].timestamp,
             event_type: 'test-plugin-lifecycle',
             context: initialContext,
-            properties: { plugin: 'analyticsPluginA', step: 'setup' },
+            properties: { plugin: 'analyticsPluginA', step: 'setup', traceId: events[0].trace?.id },
+            trace: { id: events[0].properties.traceId }, // Cross-checking with the properties.traceId to validate that they are the same
           },
           {
             timestamp: reportTestPluginLifecycleEventsAction!.meta[startEvent].timestamp,
             event_type: 'test-plugin-lifecycle',
             context: reportEventContext,
-            properties: { plugin: 'analyticsPluginA', step: 'start' },
+            properties: { plugin: 'analyticsPluginA', step: 'start', traceId: events[1].trace?.id },
+            trace: { id: events[1].properties.traceId }, // Cross-checking with the properties.traceId to validate that they are the same
           },
         ]);
       });

--- a/src/platform/test/analytics/tests/analytics_from_the_browser.ts
+++ b/src/platform/test/analytics/tests/analytics_from_the_browser.ts
@@ -154,14 +154,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             event_type: 'test-plugin-lifecycle',
             context: initialContext,
             properties: { plugin: 'analyticsPluginA', step: 'setup', traceId: events[0].trace?.id },
-            trace: { id: events[0].properties.traceId }, // Cross-checking with the properties.traceId to validate that they are the same
+            trace: { id: events[0].properties.traceId }, // Cross-checking with the properties.traceId to validate that the event reporter (plugin) and the client see the same transaction.
           },
           {
             timestamp: reportTestPluginLifecycleEventsAction!.meta[startEvent].timestamp,
             event_type: 'test-plugin-lifecycle',
             context: reportEventContext,
             properties: { plugin: 'analyticsPluginA', step: 'start', traceId: events[1].trace?.id },
-            trace: { id: events[1].properties.traceId }, // Cross-checking with the properties.traceId to validate that they are the same
+            trace: { id: events[1].properties.traceId }, // Cross-checking with the properties.traceId to validate that the event reporter (plugin) and the client see the same transaction.
           },
         ]);
       });

--- a/src/platform/test/analytics/tests/analytics_from_the_server.ts
+++ b/src/platform/test/analytics/tests/analytics_from_the_server.ts
@@ -151,13 +151,15 @@ export default function ({ getService }: FtrProviderContext) {
             timestamp: reportTestPluginLifecycleEventsAction!.meta[setupEvent].timestamp,
             event_type: 'test-plugin-lifecycle',
             context: initialContext,
-            properties: { plugin: 'analyticsPluginA', step: 'setup' },
+            properties: { plugin: 'analyticsPluginA', step: 'setup', traceId: events[0].trace?.id },
+            trace: { id: events[0].properties.traceId }, // Cross-checking with the properties.traceId to validate that the event reporter (plugin) and the client see the same transaction.
           },
           {
             timestamp: reportTestPluginLifecycleEventsAction!.meta[startEvent].timestamp,
             event_type: 'test-plugin-lifecycle',
             context: reportEventContext,
-            properties: { plugin: 'analyticsPluginA', step: 'start' },
+            properties: { plugin: 'analyticsPluginA', step: 'start', traceId: events[1].trace?.id },
+            trace: { id: events[1].properties.traceId }, // Cross-checking with the properties.traceId to validate that the event reporter (plugin) and the client see the same transaction.
           },
         ]);
       });


### PR DESCRIPTION
## Summary

Just a suggestion to make the `traceId` checks more APM-dependent in the tests (and validate that the EBT client sees the same traceId than the piece of code running `reportEvent`.
